### PR TITLE
Add rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -520,11 +520,6 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
-    "@types/gl-matrix": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@types/gl-matrix/-/gl-matrix-2.4.5.tgz",
-      "integrity": "sha512-0L8Mq1+oaIW0oVzGUDbSW+HnTjCNb4CmoIQE5BkoHt/A7x20z0MJ1PnwfH3atty/vbWLGgvJwVu2Mz3SKFiEFw=="
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -520,6 +520,11 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/gl-matrix": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@types/gl-matrix/-/gl-matrix-2.4.5.tgz",
+      "integrity": "sha512-0L8Mq1+oaIW0oVzGUDbSW+HnTjCNb4CmoIQE5BkoHt/A7x20z0MJ1PnwfH3atty/vbWLGgvJwVu2Mz3SKFiEFw=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -2657,7 +2662,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2678,12 +2684,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2698,17 +2706,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2825,7 +2836,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2837,6 +2849,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2851,6 +2864,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2858,12 +2872,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2882,6 +2898,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2962,7 +2979,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2974,6 +2992,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3059,7 +3078,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3095,6 +3115,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3114,6 +3135,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3157,12 +3179,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3269,6 +3293,11 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
       "dev": true
+    },
+    "gl-matrix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.0.0.tgz",
+      "integrity": "sha512-PD4mVH/C/Zs64kOozeFnKY8ybhgwxXXQYGWdB4h68krAHknWJgk9uKOn6z8YElh5//vs++90pb6csrTIDWnexA=="
     },
     "glob": {
       "version": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "unpkg": "build/index.umd.js",
   "scripts": {
     "build": "microbundle",
-    "dev": "microbundle watch"
+    "dev": "microbundle watch",
+    "test": "jest"
   },
   "author": "John van de Water",
   "license": "MIT",
@@ -23,5 +24,8 @@
     "microbundle": "^0.11.0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.3"
+  },
+  "dependencies": {
+    "gl-matrix": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jchn/redraw",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "canvas + jsx + hooks",
   "files": [
     "build/*",

--- a/src/__snapshots__/create-element.test.ts.snap
+++ b/src/__snapshots__/create-element.test.ts.snap
@@ -7,10 +7,10 @@ Object {
   "_depth": 0,
   "_dimensions": null,
   "_matrix": Float32Array [
+    1,
     0,
     0,
-    0,
-    0,
+    1,
     0,
     0,
   ],

--- a/src/__snapshots__/create-element.test.ts.snap
+++ b/src/__snapshots__/create-element.test.ts.snap
@@ -7,7 +7,6 @@ Object {
   "_depth": 0,
   "_dimensions": null,
   "_parent": null,
-  "_position": null,
   "props": Object {
     "children": Array [],
     "foo": "bar",

--- a/src/__snapshots__/create-element.test.ts.snap
+++ b/src/__snapshots__/create-element.test.ts.snap
@@ -6,6 +6,14 @@ Object {
   "_component": null,
   "_depth": 0,
   "_dimensions": null,
+  "_matrix": Float32Array [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  ],
   "_parent": null,
   "_position": null,
   "props": Object {

--- a/src/__snapshots__/create-element.test.ts.snap
+++ b/src/__snapshots__/create-element.test.ts.snap
@@ -6,14 +6,6 @@ Object {
   "_component": null,
   "_depth": 0,
   "_dimensions": null,
-  "_matrix": Float32Array [
-    1,
-    0,
-    0,
-    1,
-    0,
-    0,
-  ],
   "_parent": null,
   "_position": null,
   "props": Object {

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -12,7 +12,6 @@ function createVNode({ type, props }) {
     type,
     props,
     _children: null,
-    _position: null,
     _dimensions: null,
     _component: null,
     _parent: null,

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -1,3 +1,5 @@
+import { mat2d } from 'gl-matrix'
+
 function createElement(type, props, ...children) {
   return createVNode({
     type,
@@ -15,6 +17,7 @@ function createVNode({ type, props }) {
     _component: null,
     _parent: null,
     _depth: 0,
+    _matrix: mat2d.fromValues(0, 0, 0, 0, 0, 0),
   }
 }
 

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -17,7 +17,6 @@ function createVNode({ type, props }) {
     _component: null,
     _parent: null,
     _depth: 0,
-    _matrix: mat2d.fromValues(0, 0, 0, 0, 0, 0),
   }
 }
 

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -20,6 +20,7 @@ function draw(ctx, vnode, clear = true) {
         ctx,
         Object.assign({}, props, _position, _dimensions, {
           children: _children,
+          matrix: vnode._matrix,
         })
       )
       props.clip && ctx.clip()

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -17,11 +17,7 @@ function draw(ctx, vnode, clear = true) {
   if (typeof type === 'string') {
     if (type in elementTypes) {
       vnode._path = elementTypes[type].createPath(vnode)
-      elementTypes[type].draw(ctx, {
-        path: vnode._path,
-        style: vnode.props.style,
-      })
-      props.clip && ctx.clip()
+      elementTypes[type].draw(ctx, vnode)
     }
   }
 

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -16,13 +16,11 @@ function draw(ctx, vnode, clear = true) {
 
   if (typeof type === 'string') {
     if (type in elementTypes) {
-      elementTypes[type].draw(
-        ctx,
-        Object.assign({}, props, _position, _dimensions, {
-          children: _children,
-          matrix: vnode._matrix,
-        })
-      )
+      vnode._path = elementTypes[type].createPath(vnode)
+      elementTypes[type].draw(ctx, {
+        path: vnode._path,
+        style: vnode.props.style,
+      })
       props.clip && ctx.clip()
     }
   }

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -10,7 +10,7 @@ const elementTypes = {
 function draw(ctx, vnode, clear = true) {
   if (!vnode) return
   if (clear) ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
-  const { type, props, _children, _position, _dimensions } = vnode
+  const { type, _children } = vnode
 
   ctx.save()
 

--- a/src/elements/circle.ts
+++ b/src/elements/circle.ts
@@ -1,5 +1,5 @@
 import withApplyStylesToCtx, { StyleObject } from './withApplyStylesToCtx'
-import { vec2 } from 'gl-matrix'
+import { vec2, mat2d } from 'gl-matrix'
 
 interface props {
   x: number
@@ -63,6 +63,16 @@ export const createPath = vnode => {
   p.bezierCurveTo(h7[0], h7[1], h8[0], h8[1], p1[0], p1[1])
 
   return p
+}
+
+export const setAnchor = vnode => {
+  const matrix = vnode._matrix
+  const { radius, anchor = [0, 0] } = vnode.props
+
+  const offsetX = -radius * 2 * anchor[0]
+  const offsetY = -radius * 2 * anchor[1]
+
+  mat2d.translate(matrix, matrix, vec2.fromValues(offsetX, offsetY))
 }
 
 export const draw = withApplyStylesToCtx(drawCircle)

--- a/src/elements/circle.ts
+++ b/src/elements/circle.ts
@@ -1,4 +1,5 @@
 import withApplyStylesToCtx, { StyleObject } from './withApplyStylesToCtx'
+import { vec2 } from 'gl-matrix'
 
 interface props {
   x: number
@@ -9,14 +10,27 @@ interface props {
   style?: StyleObject
 }
 
-const drawCircle = (
-  ctx: CanvasRenderingContext2D,
-  { x, y, width, height, radius, style }: props
-) => {
-  ctx.beginPath()
-  ctx.arc(x, y, radius, 0, 2 * Math.PI)
-  ctx.fill()
-  if (style && style.lineWidth) ctx.stroke()
+const drawCircle = (ctx: CanvasRenderingContext2D, vnode) => {
+  const style = vnode.props.style
+  const path = vnode._path
+
+  ctx.stroke(path)
+
+  ctx.fill(path)
+  if (style && style.lineWidth) ctx.stroke(path)
+}
+
+export const createPath = vnode => {
+  const matrix = vnode._matrix
+  const { radius } = vnode.props
+  const position = vec2.fromValues(0, 0)
+
+  vec2.transformMat2d(position, position, matrix)
+
+  const p = new Path2D()
+  p.arc(position[0] + radius, position[1] + radius, radius, 0, 2 * Math.PI)
+
+  return p
 }
 
 export const draw = withApplyStylesToCtx(drawCircle)

--- a/src/elements/circle.ts
+++ b/src/elements/circle.ts
@@ -23,12 +23,44 @@ const drawCircle = (ctx: CanvasRenderingContext2D, vnode) => {
 export const createPath = vnode => {
   const matrix = vnode._matrix
   const { radius } = vnode.props
-  const position = vec2.fromValues(0, 0)
+  const p1 = vec2.fromValues(radius, 0)
+  const p2 = vec2.fromValues(radius * 2, radius)
+  const p3 = vec2.fromValues(radius, radius * 2)
+  const p4 = vec2.fromValues(0, radius)
 
-  vec2.transformMat2d(position, position, matrix)
+  const points = [p1, p2, p3, p4]
+
+  // from: https://stackoverflow.com/questions/1734745/how-to-create-circle-with-b%C3%A9zier-curves
+  const k = (4 / 3) * Math.tan(Math.PI / 8)
+
+  const offset = radius * k
+
+  const h1 = vec2.fromValues(p1[0] + offset, p1[1])
+  const h2 = vec2.fromValues(p2[0], p2[1] - offset)
+  const h3 = vec2.fromValues(p2[0], p2[1] + offset)
+  const h4 = vec2.fromValues(p3[0] + offset, p3[1])
+  const h5 = vec2.fromValues(p3[0] - offset, p3[1])
+  const h6 = vec2.fromValues(p4[0], p4[1] + offset)
+  const h7 = vec2.fromValues(p4[0], p4[1] - offset)
+  const h8 = vec2.fromValues(p1[0] - offset, p1[1])
+
+  const handles = [h1, h2, h3, h4, h5, h6, h7, h8]
+
+  points.forEach(point => {
+    vec2.transformMat2d(point, point, matrix)
+  })
+
+  handles.forEach(handle => {
+    vec2.transformMat2d(handle, handle, matrix)
+  })
 
   const p = new Path2D()
-  p.arc(position[0] + radius, position[1] + radius, radius, 0, 2 * Math.PI)
+  p.moveTo(p1[0], p1[1])
+
+  p.bezierCurveTo(h1[0], h1[1], h2[0], h2[1], p2[0], p2[1])
+  p.bezierCurveTo(h3[0], h3[1], h4[0], h4[1], p3[0], p3[1])
+  p.bezierCurveTo(h5[0], h5[1], h6[0], h6[1], p4[0], p4[1])
+  p.bezierCurveTo(h7[0], h7[1], h8[0], h8[1], p1[0], p1[1])
 
   return p
 }

--- a/src/elements/image.ts
+++ b/src/elements/image.ts
@@ -1,5 +1,5 @@
 import withApplyStylesToCtx, { StyleObject } from './withApplyStylesToCtx'
-import { vec2 } from 'gl-matrix'
+import { vec2, mat2d } from 'gl-matrix'
 
 interface props {
   x: number
@@ -44,6 +44,16 @@ export const createPath = vnode => {
   p.closePath()
 
   return p
+}
+
+export const setAnchor = vnode => {
+  const matrix = vnode._matrix
+  const { width, height, anchor = [0, 0] } = vnode.props
+
+  const offsetX = -width * anchor[0]
+  const offsetY = -height * anchor[1]
+
+  mat2d.translate(matrix, matrix, vec2.fromValues(offsetX, offsetY))
 }
 
 export const draw = withApplyStylesToCtx(drawImage)

--- a/src/elements/image.ts
+++ b/src/elements/image.ts
@@ -1,4 +1,5 @@
 import withApplyStylesToCtx, { StyleObject } from './withApplyStylesToCtx'
+import { vec2 } from 'gl-matrix'
 
 interface props {
   x: number
@@ -9,11 +10,40 @@ interface props {
   style?: StyleObject
 }
 
-const drawImage = (
-  ctx: CanvasRenderingContext2D,
-  { x, y, width, height, src }: props
-) => {
-  ctx.drawImage(src, x, y, width, height)
+const drawImage = (ctx: CanvasRenderingContext2D, vnode) => {
+  const matrix = vnode._matrix
+  const { width, height, src } = vnode.props
+  ctx.transform.apply(ctx, matrix)
+  ctx.drawImage(src, 0, 0, width, height)
+}
+
+export const createPath = vnode => {
+  const matrix = vnode._matrix
+  const { width, height } = vnode.props
+
+  const p = new Path2D()
+
+  const x1 = 0
+  const y1 = 0
+
+  const p1 = vec2.fromValues(x1, y1)
+  const p2 = vec2.fromValues(x1 + width, y1)
+  const p3 = vec2.fromValues(x1 + width, y1 + height)
+  const p4 = vec2.fromValues(x1, y1 + height)
+
+  vec2.transformMat2d(p1, p1, matrix)
+  vec2.transformMat2d(p2, p2, matrix)
+  vec2.transformMat2d(p3, p3, matrix)
+  vec2.transformMat2d(p4, p4, matrix)
+
+  p.moveTo(p1[0], p1[1])
+  p.lineTo(p2[0], p2[1])
+  p.lineTo(p3[0], p3[1])
+  p.lineTo(p4[0], p4[1])
+  p.lineTo(p1[0], p1[1])
+  p.closePath()
+
+  return p
 }
 
 export const draw = withApplyStylesToCtx(drawImage)

--- a/src/elements/rectangle.ts
+++ b/src/elements/rectangle.ts
@@ -1,5 +1,5 @@
 import withApplyStylesToCtx, { StyleObject } from './withApplyStylesToCtx'
-import { vec2 } from 'gl-matrix'
+import { vec2, mat2d } from 'gl-matrix'
 
 interface props {
   x: number
@@ -48,6 +48,16 @@ export const createPath = vnode => {
   p.closePath()
 
   return p
+}
+
+export const setAnchor = vnode => {
+  const matrix = vnode._matrix
+  const { width, height, anchor = [0, 0] } = vnode.props
+
+  const offsetX = -width * anchor[0]
+  const offsetY = -height * anchor[1]
+
+  mat2d.translate(matrix, matrix, vec2.fromValues(offsetX, offsetY))
 }
 
 export const draw = withApplyStylesToCtx(drawRect)

--- a/src/elements/rectangle.ts
+++ b/src/elements/rectangle.ts
@@ -8,12 +8,22 @@ interface props {
   height: number
   style?: StyleObject
   matrix: Float32Array
+  path: Path2D
 }
 
-const drawRect = (
-  ctx: CanvasRenderingContext2D,
-  { x, y, width, height, style, matrix }: props
-) => {
+const drawRect = (ctx: CanvasRenderingContext2D, { path, style }: props) => {
+  ctx.stroke(path)
+
+  ctx.fill(path)
+  if (style && style.lineWidth) ctx.stroke(path)
+}
+
+export const createPath = vnode => {
+  const matrix = vnode._matrix
+  const { width, height } = vnode.props
+
+  const p = new Path2D()
+
   const x1 = 0
   const y1 = 0
 
@@ -27,16 +37,14 @@ const drawRect = (
   vec2.transformMat2d(p3, p3, matrix)
   vec2.transformMat2d(p4, p4, matrix)
 
-  ctx.beginPath()
+  p.moveTo(p1[0], p1[1])
+  p.lineTo(p2[0], p2[1])
+  p.lineTo(p3[0], p3[1])
+  p.lineTo(p4[0], p4[1])
+  p.lineTo(p1[0], p1[1])
+  p.closePath()
 
-  ctx.moveTo(p1[0], p1[1])
-  ctx.lineTo(p2[0], p2[1])
-  ctx.lineTo(p3[0], p3[1])
-  ctx.lineTo(p4[0], p4[1])
-  ctx.lineTo(p1[0], p1[1])
-
-  ctx.fill()
-  if (style && style.lineWidth) ctx.stroke()
+  return p
 }
 
 export const draw = withApplyStylesToCtx(drawRect)

--- a/src/elements/rectangle.ts
+++ b/src/elements/rectangle.ts
@@ -1,4 +1,5 @@
 import withApplyStylesToCtx, { StyleObject } from './withApplyStylesToCtx'
+import { vec2 } from 'gl-matrix'
 
 interface props {
   x: number
@@ -6,14 +7,34 @@ interface props {
   width: number
   height: number
   style?: StyleObject
+  matrix: Float32Array
 }
 
 const drawRect = (
   ctx: CanvasRenderingContext2D,
-  { x, y, width, height, style }: props
+  { x, y, width, height, style, matrix }: props
 ) => {
+  const x1 = 0
+  const y1 = 0
+
+  const p1 = vec2.fromValues(x1, y1)
+  const p2 = vec2.fromValues(x1 + width, y1)
+  const p3 = vec2.fromValues(x1 + width, y1 + height)
+  const p4 = vec2.fromValues(x1, y1 + height)
+
+  vec2.transformMat2d(p1, p1, matrix)
+  vec2.transformMat2d(p2, p2, matrix)
+  vec2.transformMat2d(p3, p3, matrix)
+  vec2.transformMat2d(p4, p4, matrix)
+
   ctx.beginPath()
-  ctx.rect(x, y, width, height)
+
+  ctx.moveTo(p1[0], p1[1])
+  ctx.lineTo(p2[0], p2[1])
+  ctx.lineTo(p3[0], p3[1])
+  ctx.lineTo(p4[0], p4[1])
+  ctx.lineTo(p1[0], p1[1])
+
   ctx.fill()
   if (style && style.lineWidth) ctx.stroke()
 }

--- a/src/elements/rectangle.ts
+++ b/src/elements/rectangle.ts
@@ -11,7 +11,10 @@ interface props {
   path: Path2D
 }
 
-const drawRect = (ctx: CanvasRenderingContext2D, { path, style }: props) => {
+const drawRect = (ctx: CanvasRenderingContext2D, vnode) => {
+  const style = vnode.props.style
+  const path = vnode._path
+
   ctx.stroke(path)
 
   ctx.fill(path)

--- a/src/elements/text.ts
+++ b/src/elements/text.ts
@@ -1,4 +1,5 @@
 import withApplyStylesToCtx from './withApplyStylesToCtx'
+import { vec2 } from 'gl-matrix'
 
 interface props {
   x: number
@@ -10,10 +11,15 @@ interface props {
   children: string[]
 }
 
-const drawText = (
-  ctx: CanvasRenderingContext2D,
-  { x, y, width, fontSize, fontFamily, lineHeight = 1, children }: props
-) => {
+const drawText = (ctx: CanvasRenderingContext2D, vnode) => {
+  const { fontSize, fontFamily, width, lineHeight = 1 } = vnode.props
+  const children = vnode._children
+  const matrix = vnode._matrix
+
+  const position = vec2.fromValues(0, 0)
+
+  vec2.transformMat2d(position, position, matrix)
+
   ctx.font = `${fontSize}px ${fontFamily || 'sans-serif'}`
   const lines = children[0].split(' ').reduce(
     (lines: string[][], word) => {
@@ -31,9 +37,40 @@ const drawText = (
     [[]]
   )
 
+  ctx.transform.apply(ctx, matrix)
+
   lines.forEach((line, i) => {
-    ctx.fillText(line.join(' '), x, y + fontSize * i * lineHeight + fontSize)
+    ctx.fillText(line.join(' '), 0, 0 + fontSize * i * lineHeight + fontSize)
   })
+}
+
+export const createPath = vnode => {
+  const matrix = vnode._matrix
+  const { width, height } = vnode.props
+
+  const p = new Path2D()
+
+  const x1 = 0
+  const y1 = 0
+
+  const p1 = vec2.fromValues(x1, y1)
+  const p2 = vec2.fromValues(x1 + width, y1)
+  const p3 = vec2.fromValues(x1 + width, y1 + height)
+  const p4 = vec2.fromValues(x1, y1 + height)
+
+  vec2.transformMat2d(p1, p1, matrix)
+  vec2.transformMat2d(p2, p2, matrix)
+  vec2.transformMat2d(p3, p3, matrix)
+  vec2.transformMat2d(p4, p4, matrix)
+
+  p.moveTo(p1[0], p1[1])
+  p.lineTo(p2[0], p2[1])
+  p.lineTo(p3[0], p3[1])
+  p.lineTo(p4[0], p4[1])
+  p.lineTo(p1[0], p1[1])
+  p.closePath()
+
+  return p
 }
 
 export const draw = withApplyStylesToCtx(drawText)

--- a/src/elements/text.ts
+++ b/src/elements/text.ts
@@ -73,4 +73,8 @@ export const createPath = vnode => {
   return p
 }
 
+export const setAnchor = vnode => {
+  // no-op for now, bounding box is dependant on text
+}
+
 export const draw = withApplyStylesToCtx(drawText)

--- a/src/elements/withApplyStylesToCtx.ts
+++ b/src/elements/withApplyStylesToCtx.ts
@@ -28,14 +28,15 @@ export interface StyleObject {
 
 const withApplyStylesToCtx = drawFn => (
   ctx: CanvasRenderingContext2D,
-  props
+  vnode
 ) => {
+  const props = vnode.props
   if (!props.style) return drawFn(ctx, props)
 
   for (let key in props.style) {
     ctx[key] = props.style[key]
   }
-  drawFn(ctx, props)
+  drawFn(ctx, vnode)
 }
 
 export default withApplyStylesToCtx

--- a/src/elements/withApplyStylesToCtx.ts
+++ b/src/elements/withApplyStylesToCtx.ts
@@ -31,7 +31,7 @@ const withApplyStylesToCtx = drawFn => (
   vnode
 ) => {
   const props = vnode.props
-  if (!props.style) return drawFn(ctx, props)
+  if (!props.style) return drawFn(ctx, vnode)
 
   for (let key in props.style) {
     ctx[key] = props.style[key]

--- a/src/update.test.tsx
+++ b/src/update.test.tsx
@@ -1,5 +1,6 @@
 import createElement from './create-element'
 import update from './update'
+import { mat2d } from 'gl-matrix'
 
 describe('update element', () => {
   const vnode = <rectangle x={0} y={0} width={10} height={10} />
@@ -11,6 +12,10 @@ describe('update element', () => {
 
   it('should add _position to vnode', () => {
     expect(vnode).toHaveProperty('_position', { x: 0, y: 0 })
+  })
+
+  it('should add _matrix to vnode', () => {
+    expect(vnode).toHaveProperty('_matrix', mat2d.fromValues(0, 0, 0, 0, 0, 0))
   })
 })
 
@@ -31,6 +36,13 @@ describe('update children', () => {
       x: 30,
       y: 20,
     })
+  })
+
+  it('should add _matrix property to child node', () => {
+    expect(vnode).toHaveProperty(
+      ['_children', 0, '_matrix'],
+      mat2d.fromValues(0, 0, 0, 0, 30, 20)
+    )
   })
 })
 
@@ -66,11 +78,23 @@ describe('update function component with nested elements', () => {
     expect(vnode._children[0]._position).toStrictEqual({ x: 100, y: 100 })
   })
 
+  it('should add _matrix property to nested element', () => {
+    expect(vnode._children[0]._matrix).toStrictEqual(
+      mat2d.fromValues(0, 0, 0, 0, 100, 100)
+    )
+  })
+
   it('should offset the _position of the child element', () => {
     expect(vnode._children[0]._children[0]._position).toStrictEqual({
       x: 110,
       y: 110,
     })
+  })
+
+  it('should offset the _matrix of the child element', () => {
+    expect(vnode._children[0]._children[0]._matrix).toStrictEqual(
+      mat2d.fromValues(0, 0, 0, 0, 110, 110)
+    )
   })
 })
 
@@ -97,11 +121,23 @@ describe('function component with children prop', () => {
     expect(vnode._children[0]._position).toStrictEqual({ x: 100, y: 100 })
   })
 
+  it('should add _matrix property to nested element', () => {
+    expect(vnode._children[0]._matrix).toStrictEqual(
+      mat2d.fromValues(0, 0, 0, 0, 100, 100)
+    )
+  })
+
   it('should offset the _position of the child element', () => {
     expect(vnode._children[0]._children[0]._position).toStrictEqual({
       x: 110,
       y: 110,
     })
+  })
+
+  it('should offset the _matrix of the child element', () => {
+    expect(vnode._children[0]._children[0]._matrix).toStrictEqual(
+      mat2d.fromValues(0, 0, 0, 0, 110, 110)
+    )
   })
 })
 
@@ -145,6 +181,9 @@ describe('render props', () => {
     expect(vnode._children[0]._children[0]).toHaveProperty('type', 'circle')
     expect(vnode._children[0]._children[0]._position).toHaveProperty('x', 10)
     expect(vnode._children[0]._children[0]._position).toHaveProperty('y', 10)
+    expect(vnode._children[0]._children[0]._matrix).toEqual(
+      mat2d.fromValues(0, 0, 0, 0, 10, 10)
+    )
     expect(vnode._children[0]._children[0].props).toHaveProperty('foo', 'bar')
   })
 })

--- a/src/update.test.tsx
+++ b/src/update.test.tsx
@@ -1,6 +1,7 @@
 import createElement from './create-element'
 import update from './update'
-import { mat2d } from 'gl-matrix'
+import { mat2d, vec2 } from 'gl-matrix'
+import { deg2rad } from './utils'
 
 describe('update element', () => {
   const vnode = <rectangle x={0} y={0} width={10} height={10} />
@@ -15,7 +16,7 @@ describe('update element', () => {
   })
 
   it('should add _matrix to vnode', () => {
-    expect(vnode).toHaveProperty('_matrix', mat2d.fromValues(0, 0, 0, 0, 0, 0))
+    expect(vnode).toHaveProperty('_matrix', mat2d.fromValues(1, 0, 0, 1, 0, 0))
   })
 })
 
@@ -41,7 +42,7 @@ describe('update children', () => {
   it('should add _matrix property to child node', () => {
     expect(vnode).toHaveProperty(
       ['_children', 0, '_matrix'],
-      mat2d.fromValues(0, 0, 0, 0, 30, 20)
+      mat2d.fromValues(1, 0, 0, 1, 30, 20)
     )
   })
 })
@@ -80,7 +81,7 @@ describe('update function component with nested elements', () => {
 
   it('should add _matrix property to nested element', () => {
     expect(vnode._children[0]._matrix).toStrictEqual(
-      mat2d.fromValues(0, 0, 0, 0, 100, 100)
+      mat2d.fromValues(1, 0, 0, 1, 100, 100)
     )
   })
 
@@ -93,7 +94,7 @@ describe('update function component with nested elements', () => {
 
   it('should offset the _matrix of the child element', () => {
     expect(vnode._children[0]._children[0]._matrix).toStrictEqual(
-      mat2d.fromValues(0, 0, 0, 0, 110, 110)
+      mat2d.fromValues(1, 0, 0, 1, 110, 110)
     )
   })
 })
@@ -123,7 +124,7 @@ describe('function component with children prop', () => {
 
   it('should add _matrix property to nested element', () => {
     expect(vnode._children[0]._matrix).toStrictEqual(
-      mat2d.fromValues(0, 0, 0, 0, 100, 100)
+      mat2d.fromValues(1, 0, 0, 1, 100, 100)
     )
   })
 
@@ -136,7 +137,7 @@ describe('function component with children prop', () => {
 
   it('should offset the _matrix of the child element', () => {
     expect(vnode._children[0]._children[0]._matrix).toStrictEqual(
-      mat2d.fromValues(0, 0, 0, 0, 110, 110)
+      mat2d.fromValues(1, 0, 0, 1, 110, 110)
     )
   })
 })
@@ -182,7 +183,7 @@ describe('render props', () => {
     expect(vnode._children[0]._children[0]._position).toHaveProperty('x', 10)
     expect(vnode._children[0]._children[0]._position).toHaveProperty('y', 10)
     expect(vnode._children[0]._children[0]._matrix).toEqual(
-      mat2d.fromValues(0, 0, 0, 0, 10, 10)
+      mat2d.fromValues(1, 0, 0, 1, 10, 10)
     )
     expect(vnode._children[0]._children[0].props).toHaveProperty('foo', 'bar')
   })
@@ -194,5 +195,34 @@ describe('component instances', () => {
     update(vnode, {})
 
     expect(vnode._component).toHaveProperty('update')
+  })
+})
+
+describe('update rotation', () => {
+  const vnode = <rectangle x={10} y={10} width={10} height={10} rotate={90} />
+  it('should rotate _matrix of the vnode', () => {
+    update(vnode, {})
+
+    const expMatrix = mat2d.create()
+    mat2d.rotate(expMatrix, expMatrix, deg2rad(90))
+    mat2d.translate(expMatrix, expMatrix, vec2.fromValues(10, 10))
+
+    expect(vnode._matrix).toEqual(expMatrix)
+  })
+
+  it('should rotate the _matrix of a child of a vnode', () => {
+    const vnode = (
+      <rectangle x={10} y={10} width={100} height={100} rotate={90}>
+        <rectangle x={10} y={10} width={10} height={10} />
+      </rectangle>
+    )
+
+    update(vnode, {})
+
+    const expMatrix = mat2d.create()
+    mat2d.rotate(expMatrix, expMatrix, deg2rad(90))
+    mat2d.translate(expMatrix, expMatrix, vec2.fromValues(20, 20))
+
+    expect(vnode._children[0]._matrix).toEqual(expMatrix)
   })
 })

--- a/src/update.test.tsx
+++ b/src/update.test.tsx
@@ -204,8 +204,9 @@ describe('update rotation', () => {
     update(vnode, {})
 
     const expMatrix = mat2d.create()
-    mat2d.rotate(expMatrix, expMatrix, deg2rad(90))
+
     mat2d.translate(expMatrix, expMatrix, vec2.fromValues(10, 10))
+    mat2d.rotate(expMatrix, expMatrix, deg2rad(90))
 
     expect(vnode._matrix).toEqual(expMatrix)
   })
@@ -220,8 +221,9 @@ describe('update rotation', () => {
     update(vnode, {})
 
     const expMatrix = mat2d.create()
+    mat2d.translate(expMatrix, expMatrix, vec2.fromValues(10, 10))
     mat2d.rotate(expMatrix, expMatrix, deg2rad(90))
-    mat2d.translate(expMatrix, expMatrix, vec2.fromValues(20, 20))
+    mat2d.translate(expMatrix, expMatrix, vec2.fromValues(10, 10))
 
     expect(vnode._children[0]._matrix).toEqual(expMatrix)
   })

--- a/src/update.test.tsx
+++ b/src/update.test.tsx
@@ -11,10 +11,6 @@ describe('update element', () => {
     expect(vnode).toHaveProperty('_dimensions', { width: 10, height: 10 })
   })
 
-  it('should add _position to vnode', () => {
-    expect(vnode).toHaveProperty('_position', { x: 0, y: 0 })
-  })
-
   it('should add _matrix to vnode', () => {
     expect(vnode).toHaveProperty('_matrix', mat2d.fromValues(1, 0, 0, 1, 0, 0))
   })
@@ -30,13 +26,6 @@ describe('update children', () => {
 
   it('should add _children property with child node', () => {
     expect(vnode._children).toHaveLength(1)
-  })
-
-  it('should add _position property to child node', () => {
-    expect(vnode).toHaveProperty(['_children', 0, '_position'], {
-      x: 30,
-      y: 20,
-    })
   })
 
   it('should add _matrix property to child node', () => {
@@ -75,21 +64,10 @@ describe('update function component with nested elements', () => {
     expect(vnode._children).toHaveLength(1)
   })
 
-  it('should add _position property to nested element', () => {
-    expect(vnode._children[0]._position).toStrictEqual({ x: 100, y: 100 })
-  })
-
   it('should add _matrix property to nested element', () => {
     expect(vnode._children[0]._matrix).toStrictEqual(
       mat2d.fromValues(1, 0, 0, 1, 100, 100)
     )
-  })
-
-  it('should offset the _position of the child element', () => {
-    expect(vnode._children[0]._children[0]._position).toStrictEqual({
-      x: 110,
-      y: 110,
-    })
   })
 
   it('should offset the _matrix of the child element', () => {
@@ -118,21 +96,10 @@ describe('function component with children prop', () => {
     expect(vnode._children).toHaveLength(1)
   })
 
-  it('should add _position property to nested element', () => {
-    expect(vnode._children[0]._position).toStrictEqual({ x: 100, y: 100 })
-  })
-
   it('should add _matrix property to nested element', () => {
     expect(vnode._children[0]._matrix).toStrictEqual(
       mat2d.fromValues(1, 0, 0, 1, 100, 100)
     )
-  })
-
-  it('should offset the _position of the child element', () => {
-    expect(vnode._children[0]._children[0]._position).toStrictEqual({
-      x: 110,
-      y: 110,
-    })
   })
 
   it('should offset the _matrix of the child element', () => {
@@ -180,8 +147,6 @@ describe('render props', () => {
 
   it('should render via props', () => {
     expect(vnode._children[0]._children[0]).toHaveProperty('type', 'circle')
-    expect(vnode._children[0]._children[0]._position).toHaveProperty('x', 10)
-    expect(vnode._children[0]._children[0]._position).toHaveProperty('y', 10)
     expect(vnode._children[0]._children[0]._matrix).toEqual(
       mat2d.fromValues(1, 0, 0, 1, 10, 10)
     )

--- a/src/update.ts
+++ b/src/update.ts
@@ -35,16 +35,6 @@ function doRender(props) {
   return this.constructor(props)
 }
 
-function getLastKnownPosition(vnode) {
-  if (vnode._parent && vnode._parent._position) {
-    return vnode._parent._position
-  } else if (vnode._parent) {
-    return getLastKnownPosition(vnode._parent)
-  } else {
-    return { x: 0, y: 0 }
-  }
-}
-
 function getLastKnowMatrix(vnode) {
   if (vnode._parent && vnode._parent._matrix) {
     return vnode._parent._matrix
@@ -76,9 +66,7 @@ function update(newVNode, oldVNode) {
 
     newVNode._children = toChildArray(tmp) // probably have to do some sanitizing on this value
   } else {
-    const offset = getLastKnownPosition(newVNode)
     const parentMatrix = getLastKnowMatrix(newVNode)
-    newVNode._position = { x: newProps.x + offset.x, y: newProps.y + offset.y }
     newVNode._dimensions = { width: newProps.width, height: newProps.height }
 
     if (!newVNode._matrix) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -18,7 +18,9 @@ function Component(props) {
 }
 
 Component.prototype.update = function(all) {
-  window.requestAnimationFrame(() => render(ctx, currentVNode))
+  window.requestAnimationFrame(() =>
+    render(ctx, Object.assign({}, currentVNode))
+  )
   // if (all) {
   //   console.log('update entrire canvas for', this)
   // } else {
@@ -114,13 +116,12 @@ function updateChildren(newParentVNode, oldParentVNode) {
 
   for (let i = 0; i < newChildren.length; i++) {
     newChild = newChildren[i]
+    oldChild = oldChildren[i]
 
     if (newChild === null || typeof newChild === 'string') continue
 
     newChild._parent = newParentVNode
     newChild._depth = newParentVNode._depth + 1
-
-    oldChild = oldChildren[i]
 
     update(newChild, oldChild)
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -181,6 +181,7 @@ const setupListeners = () => {
 
     touchstart: 'onTouchStart',
     touchend: 'onTouchEnd',
+    touchcancel: 'onTouchCancel',
     touchmove: 'onTouchMove',
   }
 
@@ -209,6 +210,18 @@ const setupListeners = () => {
     const { touches } = e
     const touch = touches[0]
 
+    const { type } = e
+    let n
+
+    if (e.type === 'touchend' || e.type === 'touchcancel') {
+      for (let i = 0; i < nodes.length; i++) {
+        n = nodes[i]
+        if (eventTypeToPropName[type] in n.props) {
+          n.props[eventTypeToPropName[type]](e)
+        }
+      }
+    }
+
     if (!touch) return
 
     const { clientX, clientY } = touch
@@ -216,8 +229,6 @@ const setupListeners = () => {
     const x = clientX - canvasClientRect.x
     const y = clientY - canvasClientRect.y
 
-    const { type } = e
-    let n
     for (let i = 0; i < nodes.length; i++) {
       n = nodes[i]
       if (ctx.isPointInPath(n._path, x, y)) {
@@ -231,6 +242,7 @@ const setupListeners = () => {
 
   ctx.canvas.addEventListener('touchstart', touchEventHandler)
   ctx.canvas.addEventListener('touchend', touchEventHandler)
+  ctx.canvas.addEventListener('touchcancel', touchEventHandler)
   ctx.canvas.addEventListener('touchmove', touchEventHandler)
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,15 +1,17 @@
-import {
-  onEventToEventName,
-  eventNameToOnEventName,
-  overlap,
-  deg2rad,
-} from './utils'
+import { deg2rad } from './utils'
 import { renderComponent } from './hooks'
 import draw from './draw'
 import { mat2d, vec2 } from 'gl-matrix'
+import { rectangle, image, circle, text } from './elements'
+
+const elementTypes = {
+  rectangle,
+  image,
+  circle,
+  text,
+}
 
 let nodes: any[] = []
-let listeners = {}
 let ctx: CanvasRenderingContext2D
 
 function Component(props) {
@@ -93,6 +95,10 @@ function update(newVNode, oldVNode) {
 
     if (newProps.rotate)
       mat2d.rotate(newVNode._matrix, newVNode._matrix, deg2rad(newProps.rotate))
+
+    // needed for anchor point and updates the matrix, each element knows how to calculate its bounding box
+    // [0, 0] sets anchor to top-left, [1, 1] sets anchor to bottom-right
+    if (newProps.anchor) elementTypes[newType].setAnchor(newVNode)
 
     nodes.push(newVNode)
     newVNode._children = toChildArray(newVNode.props.children)

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,7 +1,12 @@
-import { onEventToEventName, eventNameToOnEventName, overlap } from './utils'
+import {
+  onEventToEventName,
+  eventNameToOnEventName,
+  overlap,
+  deg2rad,
+} from './utils'
 import { renderComponent } from './hooks'
 import draw from './draw'
-import { mat2d } from 'gl-matrix'
+import { mat2d, vec2 } from 'gl-matrix'
 
 let nodes: any[] = []
 let listeners = {}
@@ -40,9 +45,9 @@ function getLastKnowMatrix(vnode) {
   if (vnode._parent && vnode._parent._matrix) {
     return vnode._parent._matrix
   } else if (vnode._parent) {
-    return getLastKnownPosition(vnode._parent)
+    return getLastKnowMatrix(vnode._parent)
   } else {
-    return mat2d.fromValues(0, 0, 0, 0, 0, 0)
+    return mat2d.create()
   }
 }
 
@@ -72,11 +77,20 @@ function update(newVNode, oldVNode) {
     newVNode._position = { x: newProps.x + offset.x, y: newProps.y + offset.y }
     newVNode._dimensions = { width: newProps.width, height: newProps.height }
 
-    mat2d.add(
+    if (!newVNode._matrix) {
+      newVNode._matrix = mat2d.create()
+    }
+
+    mat2d.copy(newVNode._matrix, parentMatrix)
+
+    mat2d.translate(
       newVNode._matrix,
-      mat2d.fromValues(0, 0, 0, 0, newProps.x, newProps.y),
-      parentMatrix
+      newVNode._matrix,
+      vec2.fromValues(newProps.x, newProps.y)
     )
+
+    if (newProps.rotate)
+      mat2d.rotate(newVNode._matrix, newVNode._matrix, deg2rad(newProps.rotate))
 
     nodes.push(newVNode)
     updateEvents(newVNode.props)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,3 +42,7 @@ export function overlap(point, rectangle) {
     point.y < rectangle.y + rectangle.height
   )
 }
+
+export function deg2rad(deg) {
+  return (deg * Math.PI) / 180
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,19 +2,19 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "es2015",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "es2015" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": ["dom", "esnext"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "jsxFactory": "createElement",
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./build",                        /* Redirect output structure to the directory. */
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "outDir": "./build" /* Redirect output structure to the directory. */,
+    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -24,8 +24,8 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -40,14 +40,16 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "./src" /* Base directory to resolve non-absolute module names. */,
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    "typeRoots": ["node_modules/@types"],                       /* List of folders to include type definitions from. */
+    "typeRoots": [
+      "node_modules/@types"
+    ] /* List of folders to include type definitions from. */,
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 


### PR DESCRIPTION
Elements can be rotated using a newly added `rotate` prop.

The center point of rotation can be set using the `anchor` prop, which takes an array of two numbers where `[0, 0]` equals top-left and `[1, 1]` equals bottom-right.

`gl-matrix` has been added as a dependency to perform the matrix transformations for the rotation and positioning.